### PR TITLE
Drop QuaternionConnection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,6 @@ include_directories(lib)
 
 # Set up source files
 set(quaternion_SRCS
-    client/quaternionconnection.cpp
     client/quaternionroom.cpp
     client/message.cpp
     client/imageprovider.cpp

--- a/client/logindialog.cpp
+++ b/client/logindialog.cpp
@@ -115,7 +115,7 @@ void LoginDialog::login()
     QString user = userEdit->text();
     QString password = passwordEdit->text();
 
-    m_connection.reset(new QuaternionConnection(url));
+    m_connection.reset(new Connection(url));
 
     connect( m_connection.data(), &Connection::connected,
              this, &QDialog::accept );

--- a/client/mainwindow.h
+++ b/client/mainwindow.h
@@ -44,7 +44,6 @@ class MainWindow: public QMainWindow
         using Connection = QMatrixClient::Connection;
 
         MainWindow();
-        virtual ~MainWindow();
 
         void enableDebug();
 
@@ -68,6 +67,7 @@ class MainWindow: public QMainWindow
 
         void showLoginWindow(const QString& statusMessage = {});
         void logout(Connection* c);
+
     private:
         QList<Connection*> connections;
 


### PR DESCRIPTION
Use the newly introduced Connection::setRoomType() to have room objects of QuaternionRoom type.